### PR TITLE
Inline License as Content in spotless. Add dedicated maven profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <license-maven-plugin.version>2.5.0</license-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-        <spotless-maven-plugin.version>2.30.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>2.35.0</spotless-maven-plugin.version>
 
         <!-- Sonar Properties -->
         <sonar.organization>embabel</sonar.organization>
@@ -80,7 +80,7 @@
             <name>Apache License, Version 2.0</name>
             <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <comments>
-                Copyright 2025 the original author or authors.
+                Copyright 2024-2025 the Embabel Software Inc.
 
                 Licensed under the Apache License, Version 2.0 (the "License");
                 you may not use this file except in compliance with the License.
@@ -442,6 +442,48 @@
     </build>
 
     <profiles>
+        <!-- spotless with apache license -->
+        <!-- consider maven license plugin -->
+        <profile>
+            <id>spotless-with-license</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.diffplug.spotless</groupId>
+                        <artifactId>spotless-maven-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <kotlin>
+                                <licenseHeader>
+                                    <content>
+/*
+ * Copyright 2024-$YEAR Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+                                    </content>
+                                </licenseHeader>
+                            </kotlin>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    
         <!-- Skip tests profile -->
         <profile>
             <id>skip-tests</id>


### PR DESCRIPTION
This pull request updates the Maven configuration in `pom.xml` to enhance code formatting, licensing, and plugin management. The most significant changes include upgrading the Spotless Maven plugin version, updating copyright information, and adding a new Maven profile for Spotless with a license header.

### Plugin Updates:
* Upgraded the `spotless-maven-plugin` version from `2.30.0` to `2.35.0` to ensure compatibility with the latest features and improvements.

### Licensing Updates:
* Updated copyright information in the `<license>` section to reflect "2024-2025 Embabel Software Inc." instead of "2025 the original author or authors."

### New Maven Profile:
* Added a new Maven profile, `spotless-with-license`, which integrates the Spotless plugin with a license header configuration for Kotlin files. The license header includes Apache License 2.0 details and dynamically adjusts the year.