### PR TITLE
Create deploy-snapshots.yml

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -1,0 +1,29 @@
+# This workflow will build a Java / Kotlin project with Maven
+
+name: Deploy Snapshots
+
+on:
+  workflow_dispatch:  # Enables manual triggering
+
+jobs:
+  build-and-deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+      - name: Configure Maven Settings
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          servers: ${{secrets.GITREPO_WRITE_PACKAGE}}
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        
+        run: mvn deploy


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of Maven project snapshots. The workflow is designed to be manually triggered and supports building and deploying Java/Kotlin projects using Maven.

### New GitHub Actions Workflow:

* `.github/workflows/deploy-snapshots.yml`: Added a new workflow named "Deploy Snapshots" that:
  - Enables manual triggering via `workflow_dispatch`. 
  - Sets up a JDK 21 environment using the `actions/setup-java@v4` action with Maven caching enabled. 
  - Configures Maven settings using the `s4u/maven-settings-action@v2.8.0` action to authenticate with a secret for package repository access.
  - Runs the `mvn deploy` command to build and deploy the project.