### PR TITLE
Add configuration to generate apache license for Java source files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,6 +478,28 @@
                                     </content>
                                 </licenseHeader>
                             </kotlin>
+                            <java>
+                                <licenseHeader>
+                                    <content>
+/*
+ * Copyright 2024-$YEAR Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+                                    </content>
+                                </licenseHeader>
+                            </java>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This pull request updates the `pom.xml` file to include a license header configuration for Java files, ensuring compliance with licensing requirements.

Licensing updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R481-R502): Added a license header configuration for Java files under the Apache License, Version 2.0, to align with existing standards for Kotlin files.