### PR TITLE
Fix warning message(s) in reactor startup.

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -46,6 +46,8 @@
         <!-- Unit and Integration Testing -->
         <testcontainers.version>1.20.5</testcontainers.version>
         <springmockk.version>4.0.2</springmockk.version>
+        <!-- Build Plugins -->
+        <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -236,6 +238,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
+                <version>${flatten-maven-plugin.version}</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This pull request introduces updates to the Maven build configuration by adding new plugins and their respective versions. These changes aim to enhance build management and streamline the development process.

### Build configuration updates:

* Added the `flatten-maven-plugin` version property (`1.7.0`) to the `embabel-build-dependencies/pom.xml` file to manage its version centrally.
* Configured the `flatten-maven-plugin` in the `embabel-build-dependencies/pom.xml` file, specifying its version and disabling inheritance for better control over the build process.
* Added the `spring-boot-maven-plugin` to the `pom.xml` file, including its version property (`${spring-boot.version}`), to simplify Spring Boot application builds.