### PR TITLE
Add DCO Configuration.

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false


### PR DESCRIPTION
This pull request makes a small configuration change to the `.github/dco.yml` file. The change disables the requirement for commit authors to be organization members by setting `members` to `false`.