### PR TITLE
Add apache-commons-text managed dependency.

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -20,6 +20,8 @@
         <!-- Kotlin Version and Compiler -->
         <kotlin.version>2.1.10</kotlin.version>
         <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
+        <!-- Apache Commons -->
+        <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <!-- AI Frameworks -->
         <spring-ai.version>1.0.0-SNAPSHOT</spring-ai.version>
         <spring-ai-mcp.version>0.5.1</spring-ai-mcp.version>
@@ -69,6 +71,13 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- Apache Commons -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${apache-commons-text.version}</version>
+            </dependency>
+            
             <!-- Spring Shell -->
             <dependency>
                 <groupId>org.springframework.shell</groupId>


### PR DESCRIPTION
This pull request updates the `embabel-build-dependencies/pom.xml` file to include dependencies for Apache Commons Text. The changes primarily focus on adding the version property and the corresponding dependency entry for Apache Commons Text.

Dependency updates:

* Added a new version property for Apache Commons Text (`<apache-commons-text.version>1.10.0</apache-commons-text.version>`).
* Added a dependency entry for Apache Commons Text, specifying the group ID, artifact ID, and version.