### PR TITLE
Switch to Embabel Artifactory.

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Configure Maven Settings
         uses: s4u/maven-settings-action@v2.8.0
         with:
-          servers: ${{secrets.GITREPO_WRITE_PACKAGE}}
+          servers: ${{secrets.EMBABEL_ARTIFACTORY}}
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,11 +26,5 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-      - name: Configure Maven Settings
-        uses: s4u/maven-settings-action@v2.8.0
-        with:
-          servers: ${{secrets.GITREPO_WRITE_PACKAGE}}
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        run: mvn deploy
+      - name: Validate Build Modules
+        run: mvn test

--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -9,12 +9,6 @@
     <name>Embabel Build BOM</name>
     <packaging>pom</packaging>
     <description>BOM with Embabel Build Dependencies</description>
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>3.4.3</version>
-        <relativePath/>
-    </parent>
     <properties>
         <spring-boot.version>3.4.3</spring-boot.version>
         <!-- Kotlin Version and Compiler -->
@@ -54,6 +48,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Spring Boot -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <!-- Spring AI and MCP BOMs -->
             <dependency>
                 <groupId>org.springframework.ai</groupId>
@@ -296,11 +299,21 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>embabel-artifactory</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
     </repositories>
     <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
-        </repository>
+        <snapshotRepository>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot/</url>
+        </snapshotRepository>
     </distributionManagement>
 </project>

--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -9,6 +9,13 @@
     <packaging>pom</packaging>
     <name>Embabel Dependencies Parent</name>
     <description>Embabel Dependencies for internal modules.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
+        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+    </properties>
+    
     <url>https://embabel.com/embabel</url>
     <organization>
         <name>Embabel Software, Inc.</name>
@@ -68,16 +75,13 @@
             </roles>
         </developer>
     </developers>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>${flatten-maven-puglin.version}</version>
+                    <version>${flatten-maven-plugin.version}</version>
                     <inherited>true</inherited>
                     <executions>
                         <execution>
@@ -121,11 +125,24 @@
         </pluginManagement>
     </build>
 
-    <distributionManagement>
+    <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
+            <id>embabel-artifactory</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
+    </repositories>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot/</url>
+        </snapshotRepository>
     </distributionManagement>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
         <!-- Spring Boot -->
         <spring-boot.version>3.4.3</spring-boot.version>
 
+        <!-- Resource Delimiter -->
+        <resource.delimiter>@</resource.delimiter>
+    
         <!-- Embabel Build Version -->
         <embabel-build.version>1.0.0-SNAPSHOT</embabel-build.version>
 
@@ -45,6 +48,7 @@
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
+        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
         <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
         <license-maven-plugin.version>2.5.0</license-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
@@ -359,7 +363,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>${flatten-maven-puglin.version}</version>
+                    <version>${flatten-maven-plugin.version}</version>
                     <inherited>true</inherited>
                     <executions>
                         <execution>
@@ -374,7 +378,7 @@
                                 <pomElements>
                                     <parent>expand</parent>
                                     <distributionManagement>remove</distributionManagement>
-                                    <repositories>remove</repositories>
+                                    <repositories>keep</repositories>
                                 </pomElements>
                             </configuration>
                         </execution>
@@ -522,6 +526,14 @@
 
     <repositories>
         <repository>
+            <id>embabel-snapshots</id>
+            <name>Embabel Snapshots</name>
+            <url>https://repo.embabel.com/libs-snapshot</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>spring-milestones</id>
             <name>Spring Milestones</name>
             <url>https://repo.spring.io/milestone</url>
@@ -540,10 +552,10 @@
     </repositories>
 
     <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
-        </repository>
+        <snapshotRepository>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot/</url>
+        </snapshotRepository>
     </distributionManagement>
 
 


### PR DESCRIPTION
This pull request introduces changes to the Maven configuration for the Embabel project, focusing on migrating repository and distribution management to Artifactory, improving dependency management, and addressing plugin configuration issues. Below are the most important changes grouped by theme:

### Migration to Artifactory:
* Updated `.github/workflows/deploy-snapshots.yml` to use `secrets.EMBABEL_ARTIFACTORY` instead of `secrets.GITREPO_WRITE_PACKAGE` for Maven server configuration.
* Replaced GitHub repository URLs with Artifactory URLs (`https://repo.embabel.com/artifactory/libs-snapshot`) in `embabel-build-dependencies/pom.xml`, `embabel-dependencies-parent/pom.xml`, and `pom.xml`. This includes updating both `<repository>` and `<distributionManagement>` sections. [[1]](diffhunk://#diff-0a6158975ee79f46edff5a34ffc8b7c7d8f2b60c57a0d34631be84ea8974e963L299-R317) [[2]](diffhunk://#diff-a9c221bec5ed6d26a79e9a74625fb8900689ad1db93e6402ec4142e3dcfb356dL124-R145) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L543-R558)

### Dependency Management Improvements:
* Removed the `<parent>` declaration for `spring-boot-dependencies` in `embabel-build-dependencies/pom.xml` and replaced it with an `<import>` dependency in `<dependencyManagement>`. This change improves flexibility in managing Spring Boot dependencies. [[1]](diffhunk://#diff-0a6158975ee79f46edff5a34ffc8b7c7d8f2b60c57a0d34631be84ea8974e963L12-L17) [[2]](diffhunk://#diff-0a6158975ee79f46edff5a34ffc8b7c7d8f2b60c57a0d34631be84ea8974e963R51-R59)
* Added a new property for `maven-enforcer-plugin.version` in `pom.xml` and `embabel-dependencies-parent/pom.xml` to standardize plugin versions. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R51) [[2]](diffhunk://#diff-a9c221bec5ed6d26a79e9a74625fb8900689ad1db93e6402ec4142e3dcfb356dR12-R18)

### Plugin Configuration Fixes:
* Corrected a typo in the `flatten-maven-plugin` version property from `${flatten-maven-puglin.version}` to `${flatten-maven-plugin.version}` in `pom.xml` and `embabel-dependencies-parent/pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L362-R366) [[2]](diffhunk://#diff-a9c221bec5ed6d26a79e9a74625fb8900689ad1db93e6402ec4142e3dcfb356dL71-R84)
* Updated the `flatten-maven-plugin` configuration to retain `<repositories>` instead of removing them during the flattening process.

### Additional Enhancements:
* Introduced a new property `resource.delimiter` with the value `@` in `pom.xml` to define a custom resource delimiter.
* Added a new `<repository>` for `embabel-snapshots` in `pom.xml` to make snapshot artifacts accessible.