### PR TITLE
Upgrade Spring AI to 1.0.0-M8

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -17,7 +17,7 @@
         <!-- Apache Commons -->
         <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <!-- AI Frameworks -->
-        <spring-ai.version>1.0.0-SNAPSHOT</spring-ai.version>
+        <spring-ai.version>1.0.0-M8</spring-ai.version>
         <spring-ai-mcp.version>0.5.1</spring-ai-mcp.version>
         <!-- Kotlin Coroutines -->
         <kotlin-coroutines.version>1.10.1</kotlin-coroutines.version>
@@ -106,6 +106,12 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${kotlin.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
 


### PR DESCRIPTION
This pull request updates dependencies in the `embabel-build-dependencies/pom.xml` file to align with the latest versions and add a new Kotlin dependency.

Dependency updates:

* Updated the `spring-ai.version` from `1.0.0-SNAPSHOT` to `1.0.0-M8` to use a more stable milestone version.

New dependency:

* Added the `kotlin-stdlib` dependency to include the Kotlin standard library, ensuring compatibility with Kotlin features.