### PR TITLE
Update version to 0.1.0-SNAPSHOT

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.embabel.build</groupId>
     <artifactId>embabel-build-dependencies</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <name>Embabel Build BOM</name>
     <packaging>pom</packaging>
     <description>BOM with Embabel Build Dependencies</description>

--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.embabel.build</groupId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <artifactId>embabel-dependencies-parent</artifactId>
     <packaging>pom</packaging>
     <name>Embabel Dependencies Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.embabel.build</groupId>
     <artifactId>embabel-build-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Build Parent</name>
     <description>Embabel build parent pom, managing plugins and dependencies for all Embabel projects
@@ -39,7 +39,7 @@
         <resource.delimiter>@</resource.delimiter>
     
         <!-- Embabel Build Version -->
-        <embabel-build.version>1.0.0-SNAPSHOT</embabel-build.version>
+        <embabel-build.version>0.1.0-SNAPSHOT</embabel-build.version>
 
         <!-- Build Plugins -->
         <maven.compiler-plugin.version>3.14.0</maven.compiler-plugin.version>


### PR DESCRIPTION
This pull request updates the version numbers across several Maven `pom.xml` files to align with a new versioning scheme. The version is changed from `1.0.0-SNAPSHOT` to `0.1.0-SNAPSHOT` in multiple files.

Version updates:

* [`embabel-build-dependencies/pom.xml`](diffhunk://#diff-0a6158975ee79f46edff5a34ffc8b7c7d8f2b60c57a0d34631be84ea8974e963L8-R8): Updated the project version to `0.1.0-SNAPSHOT`.
* [`embabel-dependencies-parent/pom.xml`](diffhunk://#diff-a9c221bec5ed6d26a79e9a74625fb8900689ad1db93e6402ec4142e3dcfb356dL7-R7): Updated the project version to `0.1.0-SNAPSHOT`.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8): Updated the project version to `0.1.0-SNAPSHOT` and updated the `embabel-build.version` property to reflect the new version. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L42-R42)