### PR TITLE
Dependency Changes: Spring AI to 1.0.0; replace the expired experimental version of MCP and introduce MCP SDK 0.10.0

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -18,7 +18,7 @@
         <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <!-- AI Frameworks -->
         <spring-ai.version>1.0.0</spring-ai.version>
-        <spring-ai-mcp.version>0.5.1</spring-ai-mcp.version>
+        <mcp-sdk.version>0.10.0</mcp-sdk.version>
         <!-- Kotlin Coroutines -->
         <kotlin-coroutines.version>1.10.1</kotlin-coroutines.version>
         <!-- Ingestion Frameworks -->
@@ -67,9 +67,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.springframework.experimental</groupId>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp-bom</artifactId>
-                <version>${spring-ai-mcp.version}</version>
+                <version>${mcp-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Change Logs:

1. Spring AI to 1.0.0
2. replace the expired experimental version of MCP and introduce MCP SDK 0.10.0
 
org.springframework.experimental:mcp is an old experimental version that has been merged into Spring AI; it is recommended to remove it.
