### PR TITLE
Exclude BOM(s) from Jacoco Plugin processing.

### DIFF
--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -123,6 +123,15 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <repositories>


### PR DESCRIPTION
This pull request adds a new plugin configuration to the `embabel-dependencies-parent/pom.xml` file. The change introduces the `jacoco-maven-plugin` with a configuration to skip code coverage analysis.

* [`embabel-dependencies-parent/pom.xml`](diffhunk://#diff-a9c221bec5ed6d26a79e9a74625fb8900689ad1db93e6402ec4142e3dcfb356dR126-R134): Added the `jacoco-maven-plugin` under the `<plugins>` section with `<skip>` set to `true`, disabling code coverage analysis.