### PR TITLE
Remove HTML report from Jacoco configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,7 @@
                     <version>${jacoco-maven-plugin.version}</version>
                     <executions>
                         <execution>
+                            <id>prepare-agent</id>
                             <goals>
                                 <goal>prepare-agent</goal>
                                 <goal>report</goal>
@@ -397,7 +398,6 @@
                             <configuration>
                                 <formats>
                                     <format>XML</format>
-                                    <format>HTML</format>
                                 </formats>
                             </configuration>
                         </execution>


### PR DESCRIPTION
This pull request includes updates to the `pom.xml` file to refine the configuration of the JaCoCo Maven plugin. The changes primarily focus on improving the plugin's execution setup and output formats.

### JaCoCo Maven Plugin Configuration Updates:

* Added an `id` (`prepare-agent`) to the JaCoCo Maven plugin execution to better identify and manage the execution phase. (`[pom.xmlR386](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R386)`)
* Removed the `HTML` format from the JaCoCo report configuration, leaving only the `XML` format for output. (`[pom.xmlL400](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L400)`)