### PR TITLE
Add managed plugin for dokka documentation.

### DIFF
--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -121,6 +121,13 @@
                         </rules>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.jetbrains.dokka</groupId>
+                    <artifactId>dokka-maven-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <spotless-maven-plugin.version>2.35.0</spotless-maven-plugin.version>
+        <dokka-maven-plugin.version>1.9.20</dokka-maven-plugin.version>
 
         <!-- Sonar Properties -->
         <sonar.organization>embabel</sonar.organization>
@@ -488,6 +489,46 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
                     <version>${spring-boot.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jetbrains.dokka</groupId>
+                    <artifactId>dokka-maven-plugin</artifactId>
+                    <version>${dokka-maven-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>pre-site</phase>
+                            <goals>
+                                <goal>dokka</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <sourceDirectories>
+                            <dir>${project.basedir}/src/main/kotlin</dir>
+                            <dir>${project.basedir}/src/main/java</dir>
+                        </sourceDirectories>
+                        <samples>
+                            <dir>${project.basedir}/src/test/kotlin</dir>
+                        </samples>
+                        <reportUndocumented>true</reportUndocumented>
+                        <skipEmptyPackages>true</skipEmptyPackages>
+                        <jdkVersion>${java.version}</jdkVersion>
+                        <languageVersion>${kotlin.compiler.apiVersion}</languageVersion>
+                        <apiVersion>${kotlin.compiler.apiVersion}</apiVersion>
+                        <noStdlibLink>false</noStdlibLink>
+                        <noJdkLink>false</noJdkLink>
+                        <suppressObviousFunctions>true</suppressObviousFunctions>
+                        <outputDir>${project.build.directory}/dokka</outputDir>
+                        <moduleName>${project.name}</moduleName>
+                        <externalDocumentationLinks>
+                            <link>
+                                <url>https://docs.spring.io/spring-framework/docs/current/javadoc-api/</url>
+                            </link>
+                            <link>
+                                <url>https://docs.spring.io/spring-boot/docs/current/api/</url>
+                            </link>
+                        </externalDocumentationLinks>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This pull request introduces the `dokka-maven-plugin` to the Maven build configuration, enabling automated generation of Kotlin and Java documentation. The changes include adding the plugin to the project dependencies, configuring it for execution during the build lifecycle, and specifying detailed options for documentation generation.

### Integration of `dokka-maven-plugin`:

* **Added `dokka-maven-plugin` to `embabel-dependencies-parent/pom.xml`:** The plugin is included with a configuration to skip execution in this parent POM. This ensures it is available for child projects without running by default.
* **Defined `dokka-maven-plugin.version` in `pom.xml`:** A new property is added to manage the plugin version (`1.9.20`) centrally.

### Configuration for documentation generation:

* **Configured `dokka-maven-plugin` in `pom.xml`:** The plugin is set up to execute during the `pre-site` phase, generating documentation for both Kotlin and Java source files. Key options include:
  - Specifying source directories for main and test code.
  - Enabling reporting for undocumented elements and skipping empty packages.
  - Setting language and API versions for Kotlin.
  - Configuring output directory, module name, and external documentation links for Spring Framework and Spring Boot.