### PR TITLE
Add jacoco-code-coverage profile.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,19 @@
                 <maven.test.skip>true</maven.test.skip>
             </properties>
         </profile>
+
+        <!-- Jacoco Code Coverage -->
+        <profile>
+            <id>jacoco-code-coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <repositories>


### PR DESCRIPTION
This pull request introduces a new Maven profile to enable Jacoco code coverage reporting. The most important change is the addition of this profile to the `pom.xml` file.

### Added functionality:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R609-R621): Introduced a new Maven profile named `jacoco-code-coverage`, which includes the `jacoco-maven-plugin` for generating code coverage reports.