### PR TITLE
Prepare for Release.

### DIFF
--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
         <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     </properties>
     
     <url>https://embabel.com/embabel</url>
@@ -134,6 +135,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>jacoco-maven-plugin.version</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -623,12 +623,23 @@
 
     <repositories>
         <repository>
-            <id>embabel-snapshots</id>
-            <name>Embabel Snapshots</name>
-            <url>https://repo.embabel.com/libs-snapshot</url>
+            <id>embabel-releases</id>
+            <name>Embabel Releases</name>
+            <url>https://repo.embabel.com/artifactory/libs-release/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+        </repository>
+        <repository>
+            <id>embabel-snapshots</id>
+            <name>Embabel Snapshots</name>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
         <repository>
             <id>spring-milestones</id>
@@ -649,6 +660,10 @@
     </repositories>
 
     <distributionManagement>
+        <repository>
+            <id>embabel-releases</id>
+            <url>https://repo.embabel.com/artifactory/libs-release/</url>
+        </repository>
         <snapshotRepository>
             <id>embabel-snapshots</id>
             <url>https://repo.embabel.com/artifactory/libs-snapshot/</url>


### PR DESCRIPTION
This pull request updates Maven configuration files to improve build management and repository handling. The main changes include adding the JaCoCo plugin version property, configuring the JaCoCo plugin to use this property, and refining repository URLs and settings for Embabel releases and snapshots.

**Build tool enhancements:**

* Added `jacoco-maven-plugin.version` property to `embabel-dependencies-parent/pom.xml` for easier plugin version management.
* Configured the `jacoco-maven-plugin` in `embabel-dependencies-parent/pom.xml` to use the new version property.

**Repository configuration improvements:**

* Added a new Embabel releases repository and updated the Embabel snapshots repository URL and settings in `pom.xml` to use Artifactory and correct snapshot/release enablement.
* Updated distribution management in `pom.xml` to include the new Embabel releases repository and correct snapshot repository URLs.