### PR TITLE
Update scm tag to use https connection.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,11 +107,8 @@
     </licenses>
     <scm>
         <url>https://github.com/embabel/embabel-build</url>
-        <connection>scm:git:git://github.com/embabel/embabel-build.git
-        </connection>
-        <developerConnection>
-            scm:git:ssh://git@github.com/embabel/embabel-build.git
-        </developerConnection>
+        <connection>scm:git:https://github.com/embabel/embabel-build.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-build.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
     <developers>


### PR DESCRIPTION
This pull request updates the SCM connection URLs in the `pom.xml` file to use HTTPS instead of Git or SSH protocols, improving consistency and accessibility for repository connections.

* SCM configuration: Changed both the `connection` and `developerConnection` URLs in `pom.xml` to use the HTTPS protocol for accessing the repository.