### PR TITLE
Fix typo in the release url.

### DIFF
--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -164,7 +164,7 @@
     <distributionManagement>
         <repository>
             <id>embabel-releases</id>
-            <url>https://repo.embabel.com/artifactory/libs-releases/</url>
+            <url>https://repo.embabel.com/artifactory/libs-release/</url>
         </repository>
         <snapshotRepository>
             <id>embabel-snapshots</id>


### PR DESCRIPTION
This pull request makes a small but important change to the Maven configuration. The URL for the releases repository in the `embabel-dependencies-parent/pom.xml` file has been corrected to point to the proper path.

- Updated the `<url>` for the `embabel-releases` repository from `libs-releases` to `libs-release` in `embabel-dependencies-parent/pom.xml` to fix the repository location.