### PR TITLE
Update testcontainers dependency to 1.21.3

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -38,7 +38,8 @@
         <!-- Names Generator -->
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <!-- Unit and Integration Testing -->
-        <testcontainers.version>1.20.5</testcontainers.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
+        <mockito.version>5.18.0</mockito.version>
         <springmockk.version>4.0.2</springmockk.version>
         <!-- Build Plugins -->
         <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
@@ -256,6 +257,13 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>neo4j</artifactId>
                 <version>${testcontainers.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
This pull request updates the testing dependencies in the `embabel-build-dependencies/pom.xml` file to improve test reliability and add new mocking capabilities.

**Testing dependencies updates:**

* Upgraded the `testcontainers` library version from `1.20.5` to `1.21.3` for improved features and bug fixes.
* Added a new `mockito-core` dependency (version `5.18.0`) to enable more flexible mocking in tests.
* Introduced the `mockito.version` property to manage the version of the newly added Mockito dependency.Add managed depdency for mockito 5.18.0