### PR TITLE
Add compiler arg to get Kotlin default interface methods visible from…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
                         <jvmTarget>${maven.compiler.target}</jvmTarget>
                         <args>
                             <arg>-Xjsr305=strict</arg>
+                            <arg>-Xjvm-default=all</arg>
                         </args>
                         <compilerPlugins>
                             <plugin>spring</plugin>


### PR DESCRIPTION
This pull request introduces a small configuration update to the Kotlin compiler settings in the `pom.xml` file. The change enables support for JVM default methods across all interfaces, which can help with interoperability and reduce boilerplate in Kotlin code.

* Kotlin compiler configuration: Added the `-Xjvm-default=all` argument to the compiler options in `pom.xml` to enable default method generation for all interfaces.… Java