### PR TITLE
Suppress Kotlin Compiler UNCHECKED_CAST warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
                         <args>
                             <arg>-Xjsr305=strict</arg>
                             <arg>-Xjvm-default=all</arg>
+                            <arg>-Xsuppress-warning=UNCHECKED_CAST</arg>
                         </args>
                         <compilerPlugins>
                             <plugin>spring</plugin>


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `pom.xml` file. The change adds a compiler argument to suppress unchecked cast warnings during the build process.