### PR TITLE
Fix type in jacoco plugin version.

### DIFF
--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -133,7 +133,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>jacoco-maven-plugin.version</version>
+                <version>${jacoco-maven-plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
This pull request makes a small correction to the Maven plugin configuration in the `embabel-dependencies-parent/pom.xml` file. The change ensures the `jacoco-maven-plugin` version is referenced properly using the `${jacoco-maven-plugin.version}` property.

([embabel-dependencies-parent/pom.xmlL136-R136](diffhunk://#diff-a9c221bec5ed6d26a79e9a74625fb8900689ad1db93e6402ec4142e3dcfb356dL136-R136))