### PR TITLE
Upgrade Critical Vulnerability jar:  com.hubspot.jinjava

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -23,7 +23,7 @@
         <apache-jena-libs.version>5.3.0</apache-jena-libs.version>
         <jwiki.version>1.9.0</jwiki.version>
         <!-- Template Engine -->
-        <jinjava.version>2.7.4</jinjava.version>
+        <jinjava.version>2.8.1</jinjava.version>
         <!-- JNA Platform -->
         <jna-platform.verson>5.16.0</jna-platform.verson>
         <!-- AsciiTable -->


### PR DESCRIPTION
## Overview

please see reference on "jinjava":

https://github.com/advisories/GHSA-m49c-g9wr-hv6

```
Package
 com.hubspot.jinjava:jinjava (
[Maven](https://github.com/advisories?query=ecosystem%3Amaven)
)
Affected versions
< 2.8.1
Patched versions
2.8.1
 ```
upgraded to version 2.8.1.

## Verification

Tests passed on:
-  embabel-common (including textio)
-  embabel-agent
-  java templates, examples
