### PR TITLE
Upgrade to spring-ai 1.1.4

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -31,7 +31,7 @@
         <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>
         <!-- AI Frameworks -->
-        <spring-ai.version>1.1.3</spring-ai.version>
+        <spring-ai.version>1.1.4</spring-ai.version>
         <mcp-sdk.version>0.17.0</mcp-sdk.version>
         <!-- Kotlin Coroutines -->
         <kotlin-coroutines.version>1.10.1</kotlin-coroutines.version>


### PR DESCRIPTION
This pull request includes a minor dependency update to the project. The version of the `spring-ai` framework has been bumped from 1.1.3 to 1.1.4 in the `embabel-build-dependencies/pom.xml` file.