### PR TITLE
Upgrade Apache Tika to 3.3.0 (CVE fix for junrar)

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -52,7 +52,7 @@
         <swagger-annotations.version>2.2.28</swagger-annotations.version>
         <swagger-parser.version>2.1.25</swagger-parser.version>
         <!-- Apache Tika -->
-        <tika.version>3.2.2</tika.version>
+        <tika.version>3.3.0</tika.version>
         <!-- Netty BOM -->
         <netty.version>4.1.125.Final</netty.version>
         <!-- Embedded Tomcat -->


### PR DESCRIPTION
## Upgrade Apache Tika to 3.3.0 (CVE fix for junrar)                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                  
##  Summary                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                  
- Bump tika.version from 3.2.2 to 3.3.0 to resolve https://github.com/advisories/GHSA-j273-m5qq-6825 (medium severity)                                                                                                                                                                                          
- Tika 3.2.2 pulls junrar 7.5.5, which has an arbitrary file write via backslash path traversal bypass in LocalFolderExtractor on Linux/Unix                                                                                                                                                                    
- Tika 3.3.0 pulls junrar 7.5.8, which contains the fix                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                  
##  Affected downstream modules                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                  
- embabel-agent-rag/embabel-agent-rag-tika (inherits Tika version via embabel-dependencies-parent)                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                  
##  Test plan                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                  
- Verified embabel-agent-rag-tika resolves junrar 7.5.8 with this change                                                                                                                                                                                                                                        
- All 74 tests in embabel-agent-rag-tika pass                                                                                                                                                                                                                                                                   
- Full embabel-agent build succeeds with mvn install -DskipTests                                                                                                                                                                                                                                                
- Tested ingestion in embabel/guide
                                                                                                                                                                                                                                                                                                                  
##  Follow-up                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                  
  - After release, bump embabel-dependencies-parent version in embabel-agent/embabel-agent-dependencies/pom.xml from 0.1.12 to 0.1.13                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                  
  ---                             