### PR TITLE
Upgrade Tomcat-Embed to version 10.1.54

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -56,7 +56,7 @@
         <!-- Netty BOM -->
         <netty.version>4.1.125.Final</netty.version>
         <!-- Embedded Tomcat -->
-        <tomcat-embed.version>10.1.53</tomcat-embed.version>
+        <tomcat-embed.version>10.1.54</tomcat-embed.version>
         <!-- Names Generator -->
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <!-- jackson BOM -->


### PR DESCRIPTION
## Overview

Reported Vulnerability:
https://github.com/advisories/GHSA-rv64-5gf8-9qq8

Upgrade
from: 10.1.53
to: 10.1.54

```
|  |  |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:10.1.54:compile
[INFO] |        +- org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.54:compile
[INFO] |


```