### PR TITLE
Upgrade spring-ai to version 1.1.7

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -31,8 +31,8 @@
         <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>
         <!-- AI Frameworks -->
-        <spring-ai.version>1.1.5</spring-ai.version>
-        <mcp-sdk.version>0.17.0</mcp-sdk.version>
+        <spring-ai.version>1.1.7</spring-ai.version>
+        <mcp-sdk.version>0.18.2</mcp-sdk.version>
         <!-- Kotlin Coroutines -->
         <kotlin-coroutines.version>1.10.1</kotlin-coroutines.version>
         <!-- Ingestion Frameworks -->


### PR DESCRIPTION
This pull request updates key AI framework dependencies in the `embabel-build-dependencies/pom.xml` file to ensure compatibility with the latest features and bug fixes.

Dependency updates:

* Upgraded `spring-ai.version` from `1.1.5` to `1.1.7` to incorporate the latest improvements and fixes.
* Upgraded `mcp-sdk.version` from `0.17.0` to `0.18.2` for enhanced functionality and support.