### PR TITLE
2.0.0 synchup 1.0.1

### DIFF
--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -25,8 +25,8 @@
     <properties>
         <spring-boot.version>4.0.6</spring-boot.version>
         <!-- Kotlin Version and Compiler -->
-        <kotlin.version>2.1.10</kotlin.version>
-        <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
+        <kotlin.version>2.2.21</kotlin.version>
+        <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>
         <!-- Apache Commons -->
         <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>

--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -23,7 +23,7 @@
     <packaging>pom</packaging>
     <description>BOM with Embabel Build Dependencies</description>
     <properties>
-        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
         <!-- Kotlin Version and Compiler -->
         <kotlin.version>2.1.10</kotlin.version>
         <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
@@ -31,8 +31,8 @@
         <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>
         <!-- AI Frameworks -->
-        <spring-ai.version>1.1.7</spring-ai.version>
-        <mcp-sdk.version>0.18.2</mcp-sdk.version>
+        <spring-ai.version>2.0.0-M8</spring-ai.version>
+        <mcp-sdk.version>2.0.0-M3</mcp-sdk.version>
         <!-- Kotlin Coroutines -->
         <kotlin-coroutines.version>1.10.1</kotlin-coroutines.version>
         <!-- Ingestion Frameworks -->

--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -70,7 +70,10 @@
         <springmockk.version>4.0.2</springmockk.version>
         <archunit.version>1.4.2</archunit.version>
         <assertj-core.version>3.27.7</assertj-core.version>
-        <openai-java.version>4.16.1</openai-java.version>
+        <!-- Spring AI 2.0.0-M8's spring-ai-openai is compiled against openai-java 4.36.0;
+             bumping the BOM in lockstep avoids ABI drift between Spring AI's transitive
+             dep and any module that pulls openai-java directly. -->
+        <openai-java.version>4.36.0</openai-java.version>
     </properties>
 
     <dependencyManagement>
@@ -373,11 +376,21 @@
               <scope>test</scope>
             </dependency>
 
+            <!--
+              embabel-agent-openai uses OpenAIClient / OpenAIOkHttpClient on its main
+              classpath now (Spring AI 2.0 dropped its hand-rolled OpenAiApi wrapper),
+              so this stays at compile scope. Tests that don't transitively depend on
+              embabel-agent-openai can still depend on the artifact directly.
+            -->
             <dependency>
                 <groupId>com.openai</groupId>
                 <artifactId>openai-java</artifactId>
-                <version>${openai-java.version&gt;}</version>
-                <scope>test</scope>
+                <version>${openai-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.openai</groupId>
+                <artifactId>openai-java-client-okhttp</artifactId>
+                <version>${openai-java.version}</version>
             </dependency>
 
         </dependencies>

--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -74,6 +74,10 @@
              bumping the BOM in lockstep avoids ABI drift between Spring AI's transitive
              dep and any module that pulls openai-java directly. -->
         <openai-java.version>4.36.0</openai-java.version>
+        <!-- spring-ai-anthropic depends on anthropic-java-core but not anthropic-java-client-okhttp,
+             which the agent uses directly. Manage the Anthropic SDK in lockstep with the version
+             Spring AI compiles against, mirroring the openai-java handling above. -->
+        <anthropic-java.version>2.40.1</anthropic-java.version>
     </properties>
 
     <dependencyManagement>
@@ -391,6 +395,16 @@
                 <groupId>com.openai</groupId>
                 <artifactId>openai-java-client-okhttp</artifactId>
                 <version>${openai-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.anthropic</groupId>
+                <artifactId>anthropic-java-core</artifactId>
+                <version>${anthropic-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.anthropic</groupId>
+                <artifactId>anthropic-java-client-okhttp</artifactId>
+                <version>${anthropic-java.version}</version>
             </dependency>
 
         </dependencies>

--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.embabel.build</groupId>
     <artifactId>embabel-build-dependencies</artifactId>
-    <version>0.1.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Embabel Build BOM</name>
     <packaging>pom</packaging>
     <description>BOM with Embabel Build Dependencies</description>

--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -23,7 +23,7 @@
     <packaging>pom</packaging>
     <description>BOM with Embabel Build Dependencies</description>
     <properties>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
         <!-- Kotlin Version and Compiler -->
         <kotlin.version>2.2.21</kotlin.version>
         <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>

--- a/embabel-build-dependencies/pom.xml
+++ b/embabel-build-dependencies/pom.xml
@@ -31,8 +31,8 @@
         <apache-commons-text.version>1.10.0</apache-commons-text.version>
         <apache-commons-lang3.version>3.18.0</apache-commons-lang3.version>
         <!-- AI Frameworks -->
-        <spring-ai.version>2.0.0-M8</spring-ai.version>
-        <mcp-sdk.version>2.0.0-M3</mcp-sdk.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
+        <mcp-sdk.version>2.0.0</mcp-sdk.version>
         <!-- Kotlin Coroutines -->
         <kotlin-coroutines.version>1.10.1</kotlin-coroutines.version>
         <!-- Ingestion Frameworks -->

--- a/embabel-dependencies-parent/pom.xml
+++ b/embabel-dependencies-parent/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.embabel.build</groupId>
-    <version>0.1.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <artifactId>embabel-dependencies-parent</artifactId>
     <packaging>pom</packaging>
     <name>Embabel Dependencies Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Kotlin Version and Compiler -->
-        <kotlin.version>2.1.10</kotlin.version>
-        <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
+        <kotlin.version>2.2.21</kotlin.version>
+        <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>
 
         <!-- Spring Boot -->
         <spring-boot.version>4.0.6</spring-boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.embabel.build</groupId>
     <artifactId>embabel-build-parent</artifactId>
-    <version>0.1.14-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Embabel Build Parent</name>
     <description>Embabel build parent pom, managing plugins and dependencies for all Embabel projects

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <kotlin.compiler.apiVersion>2.2</kotlin.compiler.apiVersion>
 
         <!-- Spring Boot -->
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
 
         <!-- Resource Delimiter -->
         <resource.delimiter>@</resource.delimiter>

--- a/pom.xml
+++ b/pom.xml
@@ -46,13 +46,13 @@
         <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
 
         <!-- Spring Boot -->
-        <spring-boot.version>3.5.12</spring-boot.version>
+        <spring-boot.version>4.0.6</spring-boot.version>
 
         <!-- Resource Delimiter -->
         <resource.delimiter>@</resource.delimiter>
     
         <!-- Embabel Build Version -->
-        <embabel-build.version>0.1.14-SNAPSHOT</embabel-build.version>
+        <embabel-build.version>2.0.0-SNAPSHOT</embabel-build.version>
 
         <!-- Build Plugins -->
         <maven.compiler-plugin.version>3.14.0</maven.compiler-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,14 @@
                         <jvmTarget>${maven.compiler.target}</jvmTarget>
                         <args>
                             <arg>-Xjsr305=strict</arg>
+                            <!--
+                                JSpecify @NullMarked in Spring 7 / Spring AI 2.0 / Jackson 3 / JUnit 6 tightens
+                                generic upper bounds to non-null (T : Any). With strict mode the K2 compiler
+                                rejects unbounded <T> overrides of those APIs. "warn" reports the mismatch but
+                                does not block compilation, letting us keep the existing <T>/<O> signatures
+                                without an Any-bound sweep.
+                            -->
+                            <arg>-Xjspecify-annotations=ignore</arg>
                             <arg>-Xjvm-default=all</arg>
                             <arg>-Xsuppress-warning=UNCHECKED_CAST</arg>
                         </args>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
                             -->
                             <arg>-Xjspecify-annotations=ignore</arg>
                             <arg>-Xjvm-default=all</arg>
-                            <arg>-Xsuppress-warning=UNCHECKED_CAST</arg>
+                            <arg>-Xwarning-level=UNCHECKED_CAST:disabled</arg>
                         </args>
                         <compilerPlugins>
                             <plugin>spring</plugin>


### PR DESCRIPTION
This pull request updates the Embabel build and dependency management to support Spring Boot 4.1, Spring AI 2.0, and the latest OpenAI and Anthropic SDKs. It also bumps Kotlin to 2.2 and makes several changes to ensure compatibility with new nullness annotations introduced in Spring and related libraries.

The most important changes are:

**Major Dependency Upgrades:**
* Updated `spring-boot.version` to 4.1.0, `spring-ai.version` to 2.0.0, and `mcp-sdk.version` to 2.0.0 in `embabel-build-dependencies/pom.xml` and `pom.xml`. [[1]](diffhunk://#diff-0a6158975ee79f46edff5a34ffc8b7c7d8f2b60c57a0d34631be84ea8974e963L21-R35) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L45-R55)
* Bumped `kotlin.version` to 2.2.21 and `kotlin.compiler.apiVersion` to 2.2 across all POMs. [[1]](diffhunk://#diff-0a6158975ee79f46edff5a34ffc8b7c7d8f2b60c57a0d34631be84ea8974e963L21-R35) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L45-R55)
* Updated OpenAI and Anthropic Java SDKs to match the versions used by Spring AI 2.0, preventing ABI drift: `openai-java.version` to 4.36.0 and added `anthropic-java.version` at 2.40.1.

**Dependency Management and Scope Adjustments:**
* Added explicit dependencies on `openai-java-client-okhttp`, `anthropic-java-core`, and `anthropic-java-client-okhttp` to the BOM for proper agent support, and changed `openai-java` to compile scope.
* Updated parent POM versions (`embabel-build-parent`, `embabel-dependencies-parent`, `embabel-build-dependencies`) to 2.0.0-SNAPSHOT. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L21-R21) [[2]](diffhunk://#diff-a9c221bec5ed6d26a79e9a74625fb8900689ad1db93e6402ec4142e3dcfb356dL20-R20) [[3]](diffhunk://#diff-0a6158975ee79f46edff5a34ffc8b7c7d8f2b60c57a0d34631be84ea8974e963L21-R35)

**Kotlin Compiler Configuration:**
* Added `-Xjspecify-annotations=ignore` and adjusted warning suppression to accommodate stricter nullness annotations in Spring 7, Spring AI 2.0, and related libraries, ensuring smoother migration to new APIs.

These changes collectively modernize the build to the latest ecosystem versions and address compatibility with new nullness and generics constraints.